### PR TITLE
Add bundle page with discount script

### DIFF
--- a/scripts/bundle_discount.rb
+++ b/scripts/bundle_discount.rb
@@ -1,0 +1,24 @@
+# Applies a 25% discount to items added from the bundle page
+# when more than three qualifying items from the target collection are in the cart.
+
+COLLECTION_ID = 1234567890 # Replace with the ID of the target collection
+
+class BundleDiscount
+  def run(cart)
+    bundle_items = cart.line_items.select do |line_item|
+      line_item.product.collections.map(&:id).include?(COLLECTION_ID) &&
+        line_item.properties['added_from'] == 'bundle'
+    end
+
+    total_qty = bundle_items.map(&:quantity).reduce(0, :+)
+    return if total_qty <= 3
+
+    bundle_items.each do |line_item|
+      line_item.change_line_price(line_item.line_price * 0.75, message: 'Bundle discount')
+    end
+  end
+end
+
+campaign = BundleDiscount.new
+campaign.run(Input.cart)
+Output.cart = Input.cart

--- a/sections/bundle-products.liquid
+++ b/sections/bundle-products.liquid
@@ -1,0 +1,43 @@
+{% comment %}
+  Bundle products section allowing items to be added via AJAX with the property "added_from" set to "bundle".
+{% endcomment %}
+<script src="{{ 'product-form.js' | asset_url }}" defer="defer"></script>
+
+<div class="bundle-products">
+  {%- if section.settings.collection != blank -%}
+    {%- for product in section.settings.collection.products limit: section.settings.products_to_show -%}
+      {% render 'bundle-product-card', product: product %}
+    {%- endfor -%}
+  {%- else -%}
+    <p>Select a collection to display bundle products.</p>
+  {%- endif -%}
+</div>
+
+{% schema %}
+{
+  "name": "Bundle products",
+  "tag": "section",
+  "class": "spaced-section",
+  "settings": [
+    {
+      "type": "collection",
+      "id": "collection",
+      "label": "Collection"
+    },
+    {
+      "type": "range",
+      "id": "products_to_show",
+      "label": "Products to show",
+      "min": 1,
+      "max": 12,
+      "step": 1,
+      "default": 4
+    }
+  ],
+  "presets": [
+    {
+      "name": "Bundle products"
+    }
+  ]
+}
+{% endschema %}

--- a/snippets/bundle-product-card.liquid
+++ b/snippets/bundle-product-card.liquid
@@ -1,0 +1,13 @@
+{%- assign selected_variant = product.selected_or_first_available_variant -%}
+<div class="bundle-product-card">
+  <h3>{{ product.title }}</h3>
+  <span>{{ product.price | money }}</span>
+  <product-form>
+    <form method="post" action="/cart/add" data-type="add-to-cart-form" class="bundle-form">
+      <input type="hidden" name="id" value="{{ selected_variant.id }}">
+      <input type="hidden" name="quantity" value="1">
+      <input type="hidden" name="properties[added_from]" value="bundle">
+      <button type="submit" class="button">Add to cart</button>
+    </form>
+  </product-form>
+</div>

--- a/templates/page.bundle.json
+++ b/templates/page.bundle.json
@@ -1,0 +1,10 @@
+{
+  "sections": {
+    "main": {
+      "type": "bundle-products"
+    }
+  },
+  "order": [
+    "main"
+  ]
+}


### PR DESCRIPTION
## Summary
- create a bundle page template using new `bundle-products` section
- allow products to be added via AJAX with `added_from` property
- add Shopify Script Editor script for bundle discount logic

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68638af2d66c832b8bb117ff3af0c2e4