### PR TITLE
Fix product form error in bundle card

### DIFF
--- a/scripts/bundle_discount.rb
+++ b/scripts/bundle_discount.rb
@@ -1,0 +1,24 @@
+# Applies a 25% discount to items added from the bundle page
+# when more than three qualifying items from the target collection are in the cart.
+
+COLLECTION_ID = 1234567890 # Replace with the ID of the target collection
+
+class BundleDiscount
+  def run(cart)
+    bundle_items = cart.line_items.select do |line_item|
+      line_item.product.collections.map(&:id).include?(COLLECTION_ID) &&
+        line_item.properties['added_from'] == 'bundle'
+    end
+
+    total_qty = bundle_items.map(&:quantity).reduce(0, :+)
+    return if total_qty <= 3
+
+    bundle_items.each do |line_item|
+      line_item.change_line_price(line_item.line_price * 0.75, message: 'Bundle discount')
+    end
+  end
+end
+
+campaign = BundleDiscount.new
+campaign.run(Input.cart)
+Output.cart = Input.cart

--- a/sections/bundle-products.liquid
+++ b/sections/bundle-products.liquid
@@ -1,0 +1,43 @@
+{% comment %}
+  Bundle products section allowing items to be added via AJAX with the property "added_from" set to "bundle".
+{% endcomment %}
+<script src="{{ 'product-form.js' | asset_url }}" defer="defer"></script>
+
+<div class="bundle-products">
+  {%- if section.settings.collection != blank -%}
+    {%- for product in section.settings.collection.products limit: section.settings.products_to_show -%}
+      {% render 'bundle-product-card', product: product %}
+    {%- endfor -%}
+  {%- else -%}
+    <p>Select a collection to display bundle products.</p>
+  {%- endif -%}
+</div>
+
+{% schema %}
+{
+  "name": "Bundle products",
+  "tag": "section",
+  "class": "spaced-section",
+  "settings": [
+    {
+      "type": "collection",
+      "id": "collection",
+      "label": "Collection"
+    },
+    {
+      "type": "range",
+      "id": "products_to_show",
+      "label": "Products to show",
+      "min": 1,
+      "max": 12,
+      "step": 1,
+      "default": 4
+    }
+  ],
+  "presets": [
+    {
+      "name": "Bundle products"
+    }
+  ]
+}
+{% endschema %}

--- a/snippets/bundle-product-card.liquid
+++ b/snippets/bundle-product-card.liquid
@@ -1,0 +1,30 @@
+{%- assign selected_variant = product.selected_or_first_available_variant -%}
+<div class="bundle-product-card">
+  <h3>{{ product.title }}</h3>
+  <span>{{ product.price | money }}</span>
+<product-form class="product-form">
+  <div class="product-form__error-message-wrapper" role="alert" hidden>
+    <svg aria-hidden="true" focusable="false" role="presentation" class="icon icon-error" viewBox="0 0 13 13">
+      <circle cx="6.5" cy="6.50049" r="5.5" stroke="white" stroke-width="2" />
+      <circle cx="6.5" cy="6.5" r="5.5" fill="#EB001B" stroke="#EB001B" stroke-width="0.7" />
+      <path d="M5.87413 3.52832L5.97439 7.57216H7.02713L7.12739 3.52832H5.87413ZM6.50076 9.66091C6.88091 9.66091 7.18169 9.37267 7.18169 9.00504C7.18169 8.63742 6.88091 8.34917 6.50076 8.34917C6.12061 8.34917 5.81982 8.63742 5.81982 9.00504C5.81982 9.37267 6.12061 9.66091 6.50076 9.66091Z" fill="white" />
+      <path d="M5.87413 3.17832H5.51535L5.52424 3.537L5.6245 7.58083L5.63296 7.92216H5.97439H7.02713H7.36856L7.37702 7.58083L7.47728 3.537L7.48617 3.17832H7.12739H5.87413ZM6.50076 10.0109C7.06121 10.0109 7.5317 9.57872 7.5317 9.00504C7.5317 8.43137 7.06121 7.99918 6.50076 7.99918C5.94031 7.99918 5.46982 8.43137 5.46982 9.00504C5.46982 9.57872 5.94031 10.0109 6.50076 10.0109Z" fill="white" stroke="#EB001B" stroke-width="0.7"></path>
+    </svg>
+    <span class="product-form__error-message"></span>
+  </div>
+
+  <form method="post" action="/cart/add" data-type="add-to-cart-form" class="bundle-form">
+    <input type="hidden" name="id" value="{{ selected_variant.id }}">
+    <input type="hidden" name="quantity" value="1">
+    <input type="hidden" name="properties[added_from]" value="bundle">
+    <button type="submit" class="button">
+      Add to cart
+      <div class="loading-overlay__spinner hidden">
+        <svg aria-hidden="true" focusable="false" role="presentation" class="spinner" viewBox="0 0 66 66" xmlns="http://www.w3.org/2000/svg">
+          <circle class="path" fill="none" stroke-width="6" cx="33" cy="33" r="30"></circle>
+        </svg>
+      </div>
+    </button>
+  </form>
+</product-form>
+</div>

--- a/templates/page.bundle.json
+++ b/templates/page.bundle.json
@@ -1,0 +1,10 @@
+{
+  "sections": {
+    "main": {
+      "type": "bundle-products"
+    }
+  },
+  "order": [
+    "main"
+  ]
+}


### PR DESCRIPTION
## Summary
- include error message wrapper and spinner in the bundle product form snippet

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68638af2d66c832b8bb117ff3af0c2e4